### PR TITLE
Add support for STM32 for I2C buffer size

### DIFF
--- a/src/SparkFun_External_EEPROM.h
+++ b/src/SparkFun_External_EEPROM.h
@@ -54,6 +54,12 @@
 #define I2C_BUFFER_LENGTH_RX I2C_BUFFER_LENGTH
 #define I2C_BUFFER_LENGTH_TX I2C_BUFFER_LENGTH
 
+#elif defined(STM32)
+#elif defined(STM32)
+
+#define I2C_BUFFER_LENGTH_RX BUFFER_LENGTH //BUFFER_LENGTH is defined in Wire.h for STM32
+#define I2C_BUFFER_LENGTH_TX BUFFER_LENGTH
+
 #else
 
 #pragma GCC error "This platform doesn't have a wire buffer size defined. Please contribute to this library!"

--- a/src/SparkFun_External_EEPROM.h
+++ b/src/SparkFun_External_EEPROM.h
@@ -55,7 +55,6 @@
 #define I2C_BUFFER_LENGTH_TX I2C_BUFFER_LENGTH
 
 #elif defined(STM32)
-#elif defined(STM32)
 
 #define I2C_BUFFER_LENGTH_RX BUFFER_LENGTH //BUFFER_LENGTH is defined in Wire.h for STM32
 #define I2C_BUFFER_LENGTH_TX BUFFER_LENGTH


### PR DESCRIPTION
In the Wire.h for STM32 a #define BUFFER_SIZE 32 is available.

Closes #8 