### PR TITLE
FIX: Library does not work with small (2-16Kbits) eeprom devices

### DIFF
--- a/src/SparkFun_External_EEPROM.cpp
+++ b/src/SparkFun_External_EEPROM.cpp
@@ -161,7 +161,8 @@ void ExternalEEPROM::read(uint32_t eepromLocation, uint8_t *buff, uint16_t buffe
       delayMicroseconds(100);          //This shortens the amount of time waiting between writes but hammers the I2C bus
 
     settings.i2cPort->beginTransmission(i2cAddress);
-    settings.i2cPort->write((uint8_t)((eepromLocation + received) >> 8));   // MSB
+    if(getMemorySize() > 2048)
+      settings.i2cPort->write((uint8_t)((eepromLocation + received) >> 8));   // MSB
     settings.i2cPort->write((uint8_t)((eepromLocation + received) & 0xFF)); // LSB
     settings.i2cPort->endTransmission();
 
@@ -225,7 +226,8 @@ void ExternalEEPROM::write(uint32_t eepromLocation, const uint8_t *dataToWrite, 
       delayMicroseconds(100);          //This shortens the amount of time waiting between writes but hammers the I2C bus
 
     settings.i2cPort->beginTransmission(i2cAddress);
-    settings.i2cPort->write((uint8_t)((eepromLocation + recorded) >> 8));   // MSB
+    if(getMemorySize() > 2048)
+      settings.i2cPort->write((uint8_t)((eepromLocation + recorded) >> 8));   // MSB
     settings.i2cPort->write((uint8_t)((eepromLocation + recorded) & 0xFF)); // LSB
     for (uint8_t x = 0; x < amtToWrite; x++)
       settings.i2cPort->write(dataToWrite[recorded + x]);


### PR DESCRIPTION
For memory chips smaller than 16kbits you need to send only 1 packet (8bits) of adress via I2C.
This fix checkes for defined memory size and based on this either sends 16bit adress or 8bit address.

Tested on 2Kbits EEPROM: HT24LC02