### PR TITLE
Add support for NRF52 platform

### DIFF
--- a/src/SparkFun_External_EEPROM.h
+++ b/src/SparkFun_External_EEPROM.h
@@ -59,6 +59,11 @@
 #define I2C_BUFFER_LENGTH_RX BUFFER_LENGTH //BUFFER_LENGTH is defined in Wire.h for STM32
 #define I2C_BUFFER_LENGTH_TX BUFFER_LENGTH
 
+#elif defined(NRF52_SERIES)
+
+#define I2C_BUFFER_LENGTH_RX SERIAL_BUFFER_SIZE //Adafruit Bluefruit nRF52 Boards uses RingBuffer.h
+#define I2C_BUFFER_LENGTH_TX SERIAL_BUFFER_SIZE
+
 #else
 
 #pragma GCC warning "This platform doesn't have a wire buffer size defined. Defaulting to 32 bytes. Please contribute to this library!"


### PR DESCRIPTION
Hi all,

This PR will add support to Adafruit nRF52 based boards, which use ` RingBuffer.h` .

Cheers,

Rob.