### PR TITLE
Changes to default settings and memory size computation

### DIFF
--- a/examples/Example2_Settings/Example2_Settings.ino
+++ b/examples/Example2_Settings/Example2_Settings.ino
@@ -10,7 +10,7 @@
 
   This example demonstrates how to set the various settings for a given EEPROM.
   Read the datasheet! Each EEPROM will have specific values for:
-  Overall EEPROM size in bytes (512kbit = 64000, 256kbit = 32000)
+  Overall EEPROM size in bytes (512kbit = 65536, 256kbit = 32768)
   Bytes per page write (64 and 128 are common)
   Whether write polling is supported
   
@@ -45,10 +45,10 @@ void setup()
   Serial.println("Memory detected!");
 
   //Set settings for this EEPROM
-  myMem.setMemorySize(512000/8); //In bytes. 512kbit = 64kbyte
+  myMem.setMemorySize(512 * 1024 / 8); //In bytes. 512kbit = 64kbyte
   myMem.setPageSize(128); //In bytes. Has 128 byte page size.
   myMem.enablePollForWriteComplete(); //Supports I2C polling of write completion
-  myMem.setPageWriteTime(3); //3 ms max write time
+  myMem.setPageWriteTime(5); //5 ms max write time
 
   Serial.print("Mem size in bytes: ");
   Serial.println(myMem.length());

--- a/examples/Example5_InterfaceTest/Example5_InterfaceTest.ino
+++ b/examples/Example5_InterfaceTest/Example5_InterfaceTest.ino
@@ -48,7 +48,7 @@ void setup()
   }
   Serial.println("Memory detected!");
 
-  myMem.setMemorySize(512000 / 8); //Qwiic EEPROM is the 24512C (512k bit)
+  myMem.setMemorySize(512 * 1024 / 8); //Qwiic EEPROM is the 24512C (512k bit)
   //myMem.setPageSize(128);
   //myMem.disablePollForWriteComplete();
 

--- a/examples/Example6_UniversalProgrammer/Example6_UniversalProgrammer.ino
+++ b/examples/Example6_UniversalProgrammer/Example6_UniversalProgrammer.ino
@@ -71,7 +71,7 @@ void setup()
   beginSD();
 
   //Set settings for a 24LC1025
-  myMem.setMemorySize(1024000 / 8); //In bytes. 1024kbit = 64kbyte
+  myMem.setMemorySize(1024 * 1024 / 8); //In bytes. 1024 Kbit = 128 KB
   myMem.setPageSize(128);           //In bytes.
   myMem.enablePollForWriteComplete();
 }

--- a/src/SparkFun_External_EEPROM.cpp
+++ b/src/SparkFun_External_EEPROM.cpp
@@ -115,7 +115,7 @@ void ExternalEEPROM::disablePollForWriteComplete()
 {
   settings.pollForWriteComplete = false;
 }
-uint16_t ExternalEEPROM::getI2CBufferSize()
+constexpr uint16_t ExternalEEPROM::getI2CBufferSize()
 {
   return I2C_BUFFER_LENGTH_TX;
 }

--- a/src/SparkFun_External_EEPROM.h
+++ b/src/SparkFun_External_EEPROM.h
@@ -137,12 +137,12 @@ public:
   }
 
 private:
-  //Variables
+  // Default settings are for onsemi CAT24C51 512Kbit I2C EEPROM used on SparkFun Qwiic EEPROM Breakout
   struct_memorySettings settings = {
       .i2cPort = &Wire,
-      .deviceAddress = 0b1010000, //0b1010 + (A2 A1 A0) or 0b1010 + (B0 A1 A0) for larger (>512kbit) EEPROMs
-      .memorySize_bytes = 512000 / 8,
-      .pageSize_bytes = 64,
+      .deviceAddress = 0b1010000, 			// 0x50; format is 0b1010 + (A2 A1 A0) or 0b1010 + (B0 A1 A0) for larger (>512kbit) EEPROMs
+      .memorySize_bytes = 512 * 1024 / 8,	// equals 64 KB
+      .pageSize_bytes = 128,
       .pageWriteTime_ms = 5,
       .pollForWriteComplete = true
   };

--- a/src/SparkFun_External_EEPROM.h
+++ b/src/SparkFun_External_EEPROM.h
@@ -117,7 +117,7 @@ public:
   uint8_t getPageWriteTime();
   void enablePollForWriteComplete(); //Most EEPROMs all I2C polling of when a write has completed
   void disablePollForWriteComplete();
-  uint16_t getI2CBufferSize(); //Return the size of the TX buffer
+  constexpr uint16_t getI2CBufferSize(); //Return the size of the TX buffer
 
   //Functionality to 'get' and 'put' objects to and from EEPROM.
   template <typename T>

--- a/src/SparkFun_External_EEPROM.h
+++ b/src/SparkFun_External_EEPROM.h
@@ -92,7 +92,6 @@ struct struct_memorySettings
   uint16_t pageSize_bytes;
   uint8_t pageWriteTime_ms;
   bool pollForWriteComplete;
-  uint16_t i2cBufferSize;
 };
 
 class ExternalEEPROM
@@ -145,7 +144,7 @@ private:
       .memorySize_bytes = 512000 / 8,
       .pageSize_bytes = 64,
       .pageWriteTime_ms = 5,
-      .pollForWriteComplete = true,
+      .pollForWriteComplete = true
   };
 };
 


### PR DESCRIPTION
As per [issue #16](https://github.com/sparkfun/SparkFun_External_EEPROM_Arduino_Library/issues/16#issue-1430395461).

I wasn't able to test the settings, as I don't have large size EEPROMs available. Code compiles ok und runs with 32KB EEPROM.