### PR TITLE
Fix of signed/unsigned mismatch in variables maxWriteSize and amtToWrite

### DIFF
--- a/src/SparkFun_External_EEPROM.cpp
+++ b/src/SparkFun_External_EEPROM.cpp
@@ -816,8 +816,8 @@ int ExternalEEPROM::write(uint32_t eepromLocation, const uint8_t *dataToWrite, u
     // Serial.print("bufferSize: ");
     // Serial.println(bufferSize);
 
-    int16_t maxWriteSize = settings.pageSize_bytes;
-    if (maxWriteSize > I2C_BUFFER_LENGTH_TX - settings.addressSize_bytes)
+    uint16_t maxWriteSize = settings.pageSize_bytes;
+    if (maxWriteSize > (uint16_t)I2C_BUFFER_LENGTH_TX - settings.addressSize_bytes)
         maxWriteSize =
             I2C_BUFFER_LENGTH_TX -
             settings.addressSize_bytes; // Arduino has 32 byte limit. We loose 1 or 2 bytes to the EEPROM address
@@ -830,7 +830,7 @@ int ExternalEEPROM::write(uint32_t eepromLocation, const uint8_t *dataToWrite, u
     while (recorded < bufferSize)
     {
         // Limit the amount to write to either the page size or the Arduino limit of 30
-        int amtToWrite = bufferSize - recorded;
+        uint16_t amtToWrite = bufferSize - recorded;
 
         // Serial.print("amtToWrite: ");
         // Serial.println(amtToWrite);


### PR DESCRIPTION
I changed variable type of `amtToWrite` from `int` to `uint16_t` since it is derived as a difference of `uint16_t` variables, in order to fix problems raised in issue #48.
Following that I changed a mismatch of variable `maxWriteSize` which was declared as `int16_t` but it was assigned a value of variable with `uint16_t` type. Lastly, to fix another error about comparison of signed and unsigned variables I added an explicit cast to the if statement after declaration of `maxWriteSize`.